### PR TITLE
Upgrade fluentd to 1.15-1 and add fluent-plugin-teams for google chat

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,10 @@
-FROM quay.io/app-sre/fluentd-upstream:v1.7-1
+FROM quay.io/app-sre/fluentd-upstream:v1.15-1
 
 USER root
 
 RUN gem install fluent-plugin-s3
 RUN gem install fluent-plugin-slack
 RUN gem install fluent-plugin-cloudwatch-logs
+RUN gem install fluent-plugin-teams
 
 USER fluent

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,16 @@ FROM quay.io/app-sre/fluentd-upstream:v1.15-1
 
 USER root
 
+RUN apk add --no-cache --update --virtual .build-deps \
+        build-base ruby-dev
+
 RUN gem install fluent-plugin-s3
 RUN gem install fluent-plugin-slack
 RUN gem install fluent-plugin-cloudwatch-logs
 RUN gem install fluent-plugin-teams
+RUN gem install nokogiri
+
+RUN rm -rf /tmp/* /var/tmp/* /usr/lib/ruby/gems/*/cache/*.gem \
+    && apk del .build-deps
 
 USER fluent


### PR DESCRIPTION
This MR updates the fluentd base image to 1.15-1, as well as adding fluent-plugin-teams.

The teams plugin is targeted at Microsoft Teams, but after reviewing the code it can be applied to any general-purpose webhook endpoint which expects a json body and a text formatted record.

I have tested this plugin with google-chat in FedRAMP and it works as expected. I reviewed the backing repository as well and found it to be safe.  Quay scanning shows no vulnerabilities.