### PR TITLE
Revert upstream version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/app-sre/fluentd-upstream:v1.16-1
+FROM quay.io/app-sre/fluentd-upstream:v1.15-1
 
 USER root
 


### PR DESCRIPTION
Partial revert of #5

The Slack fluentd plugin is incompatible with v1.16-1 of Fluentd. Will need to figure out a way to upgrade our Fluentd version and keep Slack functionality intact.