### PR TITLE
include rewrite-tag-filter plugin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ RUN gem install fluent-plugin-s3
 RUN gem install fluent-plugin-slack
 RUN gem install fluent-plugin-cloudwatch-logs
 RUN gem install fluent-plugin-teams
+RUN gem install fluent-plugin-rewrite-tag-filter
 RUN gem install nokogiri
 
 RUN rm -rf /tmp/* /var/tmp/* /usr/lib/ruby/gems/*/cache/*.gem \


### PR DESCRIPTION
Part of https://issues.redhat.com/browse/APPSRE-7881

The rewrite-tag-filter is being utilized in https://github.com/app-sre/qontract-reconcile/pull/3624/files but is not included by default in Fluentd 1.15-1 so installing it in our Docker image.