### PR TITLE
update fluentd-upstream base image to 1.16-1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,16 @@
-FROM quay.io/app-sre/fluentd-upstream:v1.15-1
+FROM quay.io/app-sre/fluentd-upstream:v1.16-1
 
 USER root
 
 RUN apk add --no-cache --update --virtual .build-deps \
-        build-base ruby-dev
-
-RUN gem install fluent-plugin-s3
-RUN gem install fluent-plugin-slack
-RUN gem install fluent-plugin-cloudwatch-logs
-RUN gem install fluent-plugin-teams
-RUN gem install fluent-plugin-rewrite-tag-filter
-RUN gem install nokogiri
-
-RUN rm -rf /tmp/* /var/tmp/* /usr/lib/ruby/gems/*/cache/*.gem \
-    && apk del .build-deps
+        build-base ruby-dev \
+    && gem install fluent-plugin-s3 \
+    && gem install fluent-plugin-slack \
+    && gem install fluent-plugin-cloudwatch-logs \
+    && gem install fluent-plugin-teams \
+    && gem install fluent-plugin-rewrite-tag-filter \
+    && gem install nokogiri \
+    && apk del .build-deps \
+    && rm -rf /tmp/* /var/tmp/* /usr/lib/ruby/gems/*/cache/*.gem
 
 USER fluent

--- a/README.md
+++ b/README.md
@@ -1,9 +1,12 @@
 # fluentd
+
 An AppSRE customized version of fluentd including several plugins built into the Docker image:
 - fluent-plugin-s3
 - fluent-plugin-slack
 - fluent-plugin-cloudwatch-logs
 - fluent-plugin-teams
+
+This image uses [fluentd-upstream](https://quay.io/repository/app-sre/fluentd-upstream?tab=info) as a base image and adds the plugins mentioned above.
 
 Used as a sidecar for logging [qontract-reconcile](https://github.com/app-sre/qontract-reconcile/) & 
 [vault-manager](https://github.com/app-sre/vault-manager/) and other AppSRE projects.


### PR DESCRIPTION
Update base image to fluentd-upsteam 1.16-1.  Added a small line to the README about the image used.

Additionally consolidated RUN instructions to reduce layers.