### PR TITLE
updating dockerfile for fluentd

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,14 +5,21 @@ USER root
 RUN microdnf install -y \
     gcc \
     make \
+    ncurses-base \
+    ncurses-libs \
     redhat-rpm-config \
     ruby-devel \
-    libffi-devel \
-    zlib-devel \
+    openssl \
+    openssl-libs \
  && microdnf clean all
 
 # skip installing documentation
 RUN echo 'gem: --no-document' >> /etc/gemrc
+
+RUN curl -L https://busybox.net/downloads/binaries/1.36.0-defconfig-multiarch/busybox-x86_64 \
+    -o /usr/local/bin/busybox && \
+    chmod +x /usr/local/bin/busybox && \
+    ln -s /usr/local/bin/busybox /usr/local/bin/sh
 
 RUN gem install \
     fluent-plugin-s3 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,15 +16,21 @@ RUN microdnf install -y \
 # skip installing documentation
 RUN echo 'gem: --no-document' >> /etc/gemrc
 
-RUN gem install \
-    fluent-plugin-s3 \
-    fluent-plugin-slack \
-    fluent-plugin-cloudwatch-logs \
-    fluent-plugin-teams \
-    fluent-plugin-rewrite-tag-filter \
-    nokogiri && \
+RUN mkdir -p /fluentd
+
+WORKDIR /fluentd
+
+COPY Gemfile .
+
+RUN gem install bundler:2.4.22 && \
+    bundle config set --local path 'vendor/bundle' && \
+    bundle install && \
     rm -rf /usr/share/gems/cache/*.gem /tmp/* /var/tmp/*
-RUN touch /etc/fluent/configs.d/user/fluent.conf
+
+RUN touch /etc/fluent/fluent.conf
+
 RUN useradd --create-home --shell /bin/bash fluent
+
 USER fluent
-CMD ["fluentd", "-c", "/etc/fluent/configs.d/user/fluent.conf"]
+
+CMD ["fluentd", "-c", "/etc/fluent/fluent.conf"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,3 +38,4 @@ RUN dnf remove -y \
 
 RUN mkdir -p /fluentd/log /fluentd/etc
 USER fluent
+CMD ["fluentd"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,4 +38,5 @@ RUN dnf remove -y \
 
 RUN mkdir -p /fluentd/log /fluentd/etc
 USER fluent
+EXPOSE 24224 5140
 CMD ["fluentd"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,11 +16,6 @@ RUN microdnf install -y \
 # skip installing documentation
 RUN echo 'gem: --no-document' >> /etc/gemrc
 
-RUN curl -L https://busybox.net/downloads/binaries/1.36.0-defconfig-multiarch/busybox-x86_64 \
-    -o /usr/local/bin/busybox && \
-    chmod +x /usr/local/bin/busybox && \
-    ln -s /usr/local/bin/busybox /usr/local/bin/sh
-
 RUN gem install \
     fluent-plugin-s3 \
     fluent-plugin-slack \

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,5 +29,7 @@ RUN gem install \
     fluent-plugin-rewrite-tag-filter \
     nokogiri && \
     rm -rf /usr/share/gems/cache/*.gem /tmp/* /var/tmp/*
-
+RUN touch /etc/fluent/configs.d/user/fluent.conf
+RUN useradd --create-home --shell /bin/bash fluent
 USER fluent
+CMD ["fluentd", "-c", "/etc/fluent/configs.d/user/fluent.conf"]

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,8 @@
+source 'https://rubygems.org'
+
+gem 'fluentd', '~> 1.16.1'
+gem 'fluent-plugin-s3', '~> 1.8.3'
+gem 'fluent-plugin-slack', '~> 0.6.7'
+gem 'fluent-plugin-cloudwatch-logs', '~> 0.15.0'
+gem 'fluent-plugin-rewrite-tag-filter', '~> 2.4.0'
+gem 'nokogiri', '~> 1.18.8'


### PR DESCRIPTION
As part of the Konflux migration work. Currently Konflux cannot access the image quay.io/app-sre/fluentd-upstream
This PR updates the image to one that Konflux can access as well as updating the dockerfile to include the installation of packages with a fedora image instead of an alpine image.

Related tickets:
[APPSRE-11289](https://issues.redhat.com/browse/APPSRE-11289)
[APPSRE-11029](https://issues.redhat.com/browse/APPSRE-11029)