### PR TITLE
installing hostname for fluent-plugin-rewrite-tag-filter

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,8 @@ FROM base as prod
 WORKDIR /opt/app-root/src
 COPY --from=builder --chown=1001:0 /opt/app-root/src .
 USER 0
+# Install hostname command which is required by fluent-plugin-rewrite-tag-filter
+RUN dnf install -y hostname && dnf clean all
 RUN mkdir -p /fluentd/log /fluentd/etc /fluentd/plugins \
     && cp /opt/app-root/src/fluent/fluent.conf /fluentd/etc/fluent.conf \
     && chown -R 1001:0 /fluentd


### PR DESCRIPTION
To fix the following error:
```
bundler: failed to load command: fluentd (/opt/app-root/src/vendor/bundle/ruby/3.3.0/bin/fluentd)
/opt/app-root/src/vendor/bundle/ruby/3.3.0/gems/fluent-plugin-rewrite-tag-filter-2.4.0/lib/fluent/plugin/out_rewrite_tag_filter.rb:40:in ``': No such file or directory - hostname (Errno::ENOENT)
```